### PR TITLE
Add individual test reports and errors

### DIFF
--- a/src/pytest_md/plugin.py
+++ b/src/pytest_md/plugin.py
@@ -167,8 +167,8 @@ class MarkdownPlugin:
                         results += f" `{domaininfo}`\n"
 
                     if outcome in ("error", "failed"):
-                        results += f"```\n{report.longreprtext}\n```\n"
-                results += "\n"
+                        results += f"\n```\n{report.longreprtext}\n```\n"
+            results += "\n"
         return results
 
     def pytest_sessionfinish(self, session):
@@ -178,14 +178,18 @@ class MarkdownPlugin:
         header = self.create_header()
         project_link = self.create_project_link()
         summary = self.create_summary()
-        results = self.create_results()
 
         report = ""
         report += f"{header}\n\n"
         report += f"{project_link}\n\n"
-        report += f"{summary}\n\n"
-        report += f"{results}"
+        report += f"{summary}\n"
 
+        if self.config.option.verbose > 0:
+            results = self.create_results()
+            report += f"{results}"
+
+        # Cleanup trailing lines
+        report = f"{report.rstrip()}\n"
         self.report_path.write_text(report, encoding="utf-8")
 
 

--- a/src/pytest_md/plugin.py
+++ b/src/pytest_md/plugin.py
@@ -1,6 +1,5 @@
 import datetime
 import collections
-import html
 import pathlib
 import time
 
@@ -168,7 +167,7 @@ class MarkdownPlugin:
                         results += f" `{domaininfo}`\n"
 
                     if outcome in ("error", "failed"):
-                        results += f"```\n{report.longreprtext}```\n"
+                        results += f"```\n{report.longreprtext}\n```\n"
                 results += "\n"
         return results
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,12 +151,13 @@ def fixture_report_content(mode, now):
 
             8 tests ran in 0.00 seconds ⏱
 
+            - 1 💩
             - 1 😿
             - 3 🦊
             - 1 🙈
             - 1 🤓
             - 1 😜
-            - 1 💩"""
+            """
         )
 
     if mode is Mode.EMOJI_VERBOSE:
@@ -170,97 +171,75 @@ def fixture_report_content(mode, now):
 
             ## Summary
 
-            12 tests ran in 0.10 seconds ⏱
+            8 tests ran in 0.00 seconds ⏱
 
-                - 2 error 😡
-                - 1 failed 😰
-                - 3 passed 😃
-                - 2 skipped 🙄
-                - 2 xfail 😞
-                - 2 xpass 😲
+            - 1 error 💩
+            - 1 failed 😿
+            - 3 passed 🦊
+            - 1 skipped 🙈
+            - 1 xfailed 🤓
+            - 1 xpassed 😜
 
-            ## 2 error 😡
+            ## 1 ERROR 💩
 
-            ### test_example1.py
+            ### test_emoji_tests.py
 
-            0.02 s ⏱ `ERROR at setup of test_error`
+            0.00s ⏱  `error at setup of test_error`
 
             ```
-                @pytest.fixture
+            @pytest.fixture
                 def number():
             >       return 1234 / 0
             E       ZeroDivisionError: division by zero
 
-            test_example1.py:34: ZeroDivisionError
+            test_emoji_tests.py:37: ZeroDivisionError
             ```
 
-            ### test_example2.py
+            ## 1 FAILED 😿
 
-            0.02 s ⏱ `ERROR at setup of test_nope`
+            ### test_emoji_tests.py
 
-            ```
-                @pytest.fixture
-                def number():
-            >       return 1234 / 0
-            E       ZeroDivisionError: division by zero
-
-            test_example2.py:23: ZeroDivisionError
-            ```
-
-            ## 1 failed 😰
-
-            0.22 s ⏱ `test_failed`
+            0.00s ⏱  `test_failed`
 
             ```
-                def test_failed():
+            def test_failed():
             >       assert "emoji" == "hello world"
             E       AssertionError: assert 'emoji' == 'hello world'
             E         - emoji
             E         + hello world
 
-            test_example1.py:6: AssertionError
+            test_emoji_tests.py:5: AssertionError
             ```
 
-            ## 3 passed 😃
+            ## 3 PASSED 🦊
 
-            ### test_example1.py
+            ### test_emoji_tests.py
 
-            0.08 s ⏱ `test_passed[Sara-Hello Sara!]`
-            0.07 s ⏱ `test_passed[Mat-Hello Mat!]`
-            0.08 s ⏱ `test_passed[Annie-Hello Annie!]`
+            0.00s ⏱  `test_passed[Sara-Hello Sara!]`
+            0.00s ⏱  `test_passed[Mat-Hello Mat!]`
+            0.00s ⏱  `test_passed[Annie-Hello Annie!]`
 
-            ## 2 skipped 🙄
+            ## 1 SKIPPED 🙈
 
-            ### test_example1.py
+            ### test_emoji_tests.py
 
-            0.00 s ⏱ `test_skipped`
+            0.00s ⏱  `test_skipped`
 
-            ### test_example2.py
+            ## 1 XFAILED 🤓
 
-            0.00 s ⏱ `test_skipped`
+            ### test_emoji_tests.py
 
-            ## 2 xfail 😞
+            0.00s ⏱  `test_xfailed`
 
-            ### test_example1.py
+            ## 1 XPASSED 😜
 
-            0.40 s ⏱ `test_xfail`
+            ### test_emoji_tests.py
 
-            ### test_example2.py
-
-            0.20 s ⏱ `test_xfail`
-
-            ## xpass 😲
-
-            ### test_example1.py
-
-            0.42 s ⏱ `test_xpass`
-
-            ### test_example2.py
-
-            0.22 s ⏱ `test_xpass`
-"""
+            0.00s ⏱  `test_xpass`
+            """
         )
 
+    # Return the default report for Mode.NORMAL and Mode.VERBOSE
     if mode is Mode.VERBOSE:
         return textwrap.dedent(
             f"""\
@@ -274,15 +253,71 @@ def fixture_report_content(mode, now):
 
             8 tests ran in 0.00 seconds
 
+            - 1 error
             - 1 failed
             - 3 passed
             - 1 skipped
             - 1 xfailed
             - 1 xpassed
-            - 1 error"""
-        )
 
-    # Return the default report for Mode.NORMAL
+            ## 1 error
+
+            ### test_emoji_tests.py
+
+            0.00s `error at setup of test_error`
+
+            ```
+            @pytest.fixture
+                def number():
+            >       return 1234 / 0
+            E       ZeroDivisionError: division by zero
+
+            test_emoji_tests.py:37: ZeroDivisionError
+            ```
+
+            ## 1 failed
+
+            ### test_emoji_tests.py
+
+            0.00s `test_failed`
+
+            ```
+            def test_failed():
+            >       assert "emoji" == "hello world"
+            E       AssertionError: assert 'emoji' == 'hello world'
+            E         - emoji
+            E         + hello world
+
+            test_emoji_tests.py:5: AssertionError
+            ```
+
+            ## 3 passed
+
+            ### test_emoji_tests.py
+
+            0.00s `test_passed[Sara-Hello Sara!]`
+            0.00s `test_passed[Mat-Hello Mat!]`
+            0.00s `test_passed[Annie-Hello Annie!]`
+
+            ## 1 skipped
+
+            ### test_emoji_tests.py
+
+            0.00s `test_skipped`
+
+            ## 1 xfailed
+
+            ### test_emoji_tests.py
+
+            0.00s `test_xfailed`
+
+            ## 1 xpassed
+
+            ### test_emoji_tests.py
+
+            0.00s `test_xpass`
+            """
+        )
     return textwrap.dedent(
         f"""\
         # Test Report
@@ -295,12 +330,13 @@ def fixture_report_content(mode, now):
 
         8 tests ran in 0.00 seconds
 
+        - 1 error
         - 1 failed
         - 3 passed
         - 1 skipped
         - 1 xfailed
         - 1 xpassed
-        - 1 error"""
+        """
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,8 +156,7 @@ def fixture_report_content(mode, now):
             - 1 🙈
             - 1 🤓
             - 1 😜
-            - 1 💩
-            """
+            - 1 💩"""
         )
 
     if mode is Mode.EMOJI_VERBOSE:
@@ -171,18 +170,119 @@ def fixture_report_content(mode, now):
 
             ## Summary
 
-            8 tests ran in 0.00 seconds ⏱
+            12 tests ran in 0.10 seconds ⏱
 
-            - 1 failed 😿
-            - 3 passed 🦊
-            - 1 skipped 🙈
-            - 1 xfailed 🤓
-            - 1 xpassed 😜
-            - 1 error 💩
-            """
+                - 2 error 😡
+                - 1 failed 😰
+                - 3 passed 😃
+                - 2 skipped 🙄
+                - 2 xfail 😞
+                - 2 xpass 😲
+
+            ## 2 error 😡
+
+            ### test_example1.py
+
+            0.02 s ⏱ `ERROR at setup of test_error`
+
+            ```
+                @pytest.fixture
+                def number():
+            >       return 1234 / 0
+            E       ZeroDivisionError: division by zero
+
+            test_example1.py:34: ZeroDivisionError
+            ```
+
+            ### test_example2.py
+
+            0.02 s ⏱ `ERROR at setup of test_nope`
+
+            ```
+                @pytest.fixture
+                def number():
+            >       return 1234 / 0
+            E       ZeroDivisionError: division by zero
+
+            test_example2.py:23: ZeroDivisionError
+            ```
+
+            ## 1 failed 😰
+
+            0.22 s ⏱ `test_failed`
+
+            ```
+                def test_failed():
+            >       assert "emoji" == "hello world"
+            E       AssertionError: assert 'emoji' == 'hello world'
+            E         - emoji
+            E         + hello world
+
+            test_example1.py:6: AssertionError
+            ```
+
+            ## 3 passed 😃
+
+            ### test_example1.py
+
+            0.08 s ⏱ `test_passed[Sara-Hello Sara!]`
+            0.07 s ⏱ `test_passed[Mat-Hello Mat!]`
+            0.08 s ⏱ `test_passed[Annie-Hello Annie!]`
+
+            ## 2 skipped 🙄
+
+            ### test_example1.py
+
+            0.00 s ⏱ `test_skipped`
+
+            ### test_example2.py
+
+            0.00 s ⏱ `test_skipped`
+
+            ## 2 xfail 😞
+
+            ### test_example1.py
+
+            0.40 s ⏱ `test_xfail`
+
+            ### test_example2.py
+
+            0.20 s ⏱ `test_xfail`
+
+            ## xpass 😲
+
+            ### test_example1.py
+
+            0.42 s ⏱ `test_xpass`
+
+            ### test_example2.py
+
+            0.22 s ⏱ `test_xpass`
+"""
         )
 
-    # Return the default report for Mode.NORMAL and Mode.VERBOSE
+    if mode is Mode.VERBOSE:
+        return textwrap.dedent(
+            f"""\
+            # Test Report
+
+            *Report generated on {report_date} at {report_time} by [pytest-md]*
+
+            [pytest-md]: https://github.com/hackebrot/pytest-md
+
+            ## Summary
+
+            8 tests ran in 0.00 seconds
+
+            - 1 failed
+            - 3 passed
+            - 1 skipped
+            - 1 xfailed
+            - 1 xpassed
+            - 1 error"""
+        )
+
+    # Return the default report for Mode.NORMAL
     return textwrap.dedent(
         f"""\
         # Test Report
@@ -200,8 +300,7 @@ def fixture_report_content(mode, now):
         - 1 skipped
         - 1 xfailed
         - 1 xpassed
-        - 1 error
-        """
+        - 1 error"""
     )
 
 


### PR DESCRIPTION
This adds individual test and reporting functionality similar to the
given output of pytest-html. As there is no support for collapsing
columns together in Markdown implementations we drop down to bare HTML
so we can use `colspan=3` and make the inline table output for test
results a lot cleaner at the expense of .md readability.

Issue: https://github.com/hackebrot/pytest-md/issues/7